### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Building the installer
 In order to build the installer, you'll need to install some tools.
 
 1. Download and install Node for Windows from <https://nodejs.org/en/download/>. Pick the MSI installer.
-2. Download and install MS Visual Studio Express 2015 from <https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx> (pick the Express for Desktop installer) or Microsoft Visual C++ 2010 SP1 Redistributable Package from <http://www.microsoft.com/en-us/download/details.aspx?id=8328>
+2a. Download and install MS Visual Studio Express 2015 from <https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx> (pick the Express for Desktop installer) - *Note that you need 14GB free to install this*, or
+2b. Microsoft Visual C++ 2010 SP1 Redistributable Package from <http://www.microsoft.com/en-us/download/details.aspx?id=8328> - *Note that you will need a Microsoft Live account to access this.*
 3. Download and install Python 2.7.x for Windows from <https://www.python.org/downloads/release/>
 4. Edit your "Path" by going to the "System" Control Panel, "Advanced system settings", "Environment Variables". Add _C:\Program Files\nodejs;C:\Users\<username>\App Data\Roaming\npm_ to the "Variable value"
 5. Install Gulp and jspm:


### PR DESCRIPTION
Add note about 14GB disk space requirement for installing Visual Studio Express Desktop; add note that you need a Live account for access to the Visual C++ package.
